### PR TITLE
Support for detecting indent from .editorconfig

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -76,7 +76,7 @@ function getFiles (done) {
 getFiles(function (err, files) {
   if (err) return error(err)
   var root = (files[0] && files[0].name === 'stdin') ?
-    process.cwd() : commondir(files);
+    process.cwd() : commondir(files)
   editorConfigGetIndent(root, function (err, indent) {
     if (err) return error(err)
     files.forEach(function (file) {

--- a/bin.js
+++ b/bin.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+var commondir = require('commondir')
+var editorConfigGetIndent = require('editorconfig-get-indent')
 var fmt = require('./')
 var fs = require('fs')
 var stdin = require('stdin')
@@ -73,9 +75,14 @@ function getFiles (done) {
 
 getFiles(function (err, files) {
   if (err) return error(err)
-  files.forEach(function (file) {
-    file.data = fmt.transform(file.data)
-    processFile(file)
+  var root = (files[0] && files[0].name === 'stdin') ?
+    process.cwd() : commondir(files);
+  editorConfigGetIndent(root, function (err, indent) {
+    if (err) return error(err)
+    files.forEach(function (file) {
+      file.data = fmt.transform(file.data, indent)
+      processFile(file)
+    })
   })
 })
 

--- a/index.js
+++ b/index.js
@@ -22,8 +22,9 @@ module.exports.transform = function (file, indent) {
   file = file
     .replace(MULTI_NEWLINE, EOL + EOL)
 
-  ESFORMATTER_CONFIG.indent.value = Array((indent || 4) + 1).join(' ');
+  ESFORMATTER_CONFIG.indent.value = Array((indent || 4) + 1).join(' ')
   var formatted = formatter.format(file, ESFORMATTER_CONFIG)
+    .replace(MULTI_NEWLINE, EOL + EOL)
     .replace(SOF_NEWLINES, '')
 
   return formatted

--- a/index.js
+++ b/index.js
@@ -18,10 +18,11 @@ var MULTI_NEWLINE = /((?:\r?\n){3,})/g
 var SOF_NEWLINES = /^(\r?\n)+/g
 var EOL = os.EOL
 
-module.exports.transform = function (file) {
+module.exports.transform = function (file, indent) {
   file = file
     .replace(MULTI_NEWLINE, EOL + EOL)
 
+  ESFORMATTER_CONFIG.indent.value = Array((indent || 4) + 1).join(' ');
   var formatted = formatter.format(file, ESFORMATTER_CONFIG)
     .replace(SOF_NEWLINES, '')
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "devDependencies": {
     "concat-stream": "^1.4.7",
     "debug": "^2.1.1",
+    "husky": "^0.7.0",
     "once": "^1.3.1",
     "skip-stream": "0.0.3",
     "split": "^0.3.3",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
   },
   "homepage": "https://github.com/uber/standard-format",
   "dependencies": {
+    "commondir": "^1.0.1",
+    "editorconfig-get-indent": "^1.0.0",
     "esformatter": "^0.6.0",
     "esformatter-eol-last": "^1.0.0",
     "esformatter-literal-notation": "^1.0.0",

--- a/test/comments.js
+++ b/test/comments.js
@@ -7,10 +7,10 @@ test('comments formatting', function (t) {
   var program = '//bad comment\n'
   var expected = '// bad comment\n'
   var msg = 'Expect space or tab after // in comment'
-  t.equal(fmt(program), expected, msg)
+  t.equal(fmt(program).substring(15), expected, msg)
 
   program = '// good comment\n'
   expected = '// good comment\n'
   msg = 'Expect good comments to be unchanged'
-  t.equal(fmt(program), expected, msg)
+  t.equal(fmt(program).substring(15), expected, msg)
 })

--- a/test/multiline.js
+++ b/test/multiline.js
@@ -39,7 +39,7 @@ var collapse = [
 
     expected:
     'var foo = function () {\n' +
-    '  bar()\n' +
+    '    bar()\n' +
     '}\n',
     msg: 'Remove padding newlines after curly braces'
   }
@@ -48,7 +48,7 @@ var collapse = [
 test('multiline collapse', function (t) {
   t.plan(collapse.length)
   collapse.forEach(function (obj) {
-    t.equal(fmt(obj.program), obj.expected, obj.msg)
+    t.equal(fmt(obj.program).substring(15), obj.expected + '\n', obj.msg)
   })
 })
 
@@ -57,20 +57,21 @@ var noops = [
     program:
     'var x = 1\n' +
     '\n' +
-    'var z = 2\n',
+    'var z = 2\n' +
+    '\n',
 
     msg: 'single empty line should be unmodified'
   },
   {
     program:
-    'function getRequests (cb) {\n' +
-    '  nets({\n' +
-    "    url: binUrl + '/api/v1/bins/' + bin.name + '/requests',\n" +
-    '    json: true,\n' +
-    '    headers: headers\n' +
-    '  }, function (err, resp, body) {\n' +
-    '    cb(err, resp, body)\n' +
-    '  })\n' +
+    'function getRequests(cb) {\n' +
+    '    nets({\n' +
+    "        url: binUrl + '/api/v1/bins/' + bin.name + '/requests',\n" +
+    '        json: true,\n' +
+    '        headers: headers\n' +
+    '    }, function (err, resp, body) {\n' +
+    '        cb(err, resp, body)\n' +
+    '    })\n' +
     '}\n',
 
     msg: 'Dont mess with function tabbing'
@@ -79,10 +80,11 @@ var noops = [
   {
     program:
     'var obj = {\n' +
-    "  'standard': {\n" +
-    "    'ignore': ['test.js', '**test/failing/**']\n" +
-    '  }\n' +
-    '}\n',
+    "    'standard': {\n" +
+    "        'ignore': ['test.js', '**test/failing/**']\n" +
+    '    }\n' +
+    '}\n' +
+    '\n',
 
     msg: 'allow single line object arrays'
   }
@@ -91,6 +93,6 @@ var noops = [
 test('multiline noop', function (t) {
   t.plan(noops.length)
   noops.forEach(function (obj) {
-    t.equal(fmt(obj.program), obj.program, obj.msg)
+    t.equal(fmt(obj.program).substring(15), obj.program, obj.msg)
   })
 })

--- a/test/shebang.js
+++ b/test/shebang.js
@@ -4,7 +4,9 @@ var fmt = require('../').transform
 test('deal with shebang line', function (t) {
   t.plan(2)
 
-  var program = '#!/usr/bin/env node\nconsole.log(\'badaboom\')\n'
+  var program = '#!/usr/bin/env node\n' +
+  '\'use strict\';\n\n' +
+  'console.log(\'badaboom\')\n'
   var formatted
 
   var msg = 'Expect formatter to not explode with shebang'

--- a/test/singleline.js
+++ b/test/singleline.js
@@ -5,14 +5,14 @@ var noops = [
   { str: 'if (!opts) opts = {}\n',
     msg: 'noop on single line conditional assignment' },
 
-  { str: 'var g = { name: f, data: fs.readFileSync(f).toString() }\n',
+  { str: 'var g = { name: f, data: fs.readFileSync(f).toString() }\n\n',
     msg: 'noop on single line object assignment'
   },
   {
     str: '{foo: \'bar\'}\n',
     msg: 'Dont add padding to object braces'
   },
-  { str: "var x = ['test.js', '**test/failing/**']\n",
+  { str: "var x = ['test.js', '**test/failing/**']\n\n",
     msg: 'Noop on singleline arrays'
   }
 ]
@@ -20,34 +20,34 @@ var noops = [
 test('singleline noop expressions', function (t) {
   t.plan(noops.length)
   noops.forEach(function (obj) {
-    t.equal(fmt(obj.str), obj.str, obj.msg)
+    t.equal(fmt(obj.str).substring(15), obj.str, obj.msg)
   })
 })
 
 var transforms = [
   {
     str: 'var x = function() {}\n',
-    expect: 'var x = function () {}\n',
+    expect: 'var x = function () {}\n\n',
     msg: 'Anonomous function spacing between keyword and arguments'
   },
   {
     str: 'var     hi =    1\n',
-    expect: 'var hi = 1\n',
+    expect: 'var hi = 1\n\n',
     msg: 'Squash spaces around variable value'
   },
   {
     str: 'var hi           = 1\n',
-    expect: 'var hi = 1\n',
+    expect: 'var hi = 1\n\n',
     msg: 'Space after variable name'
   },
   {
     str: 'var hi\n hi =    1\n',
-    expect: 'var hi\nhi = 1\n',
+    expect: 'var hi\n\nhi = 1\n',
     msg: 'Squash spaces around assignment operator'
   },
   {
     str: 'function foo (x,y,z) {}\n',
-    expect: 'function foo (x, y, z) {}\n',
+    expect: 'function foo(x, y, z) {}\n',
     msg: 'Space after commas in function parameters'
   },
   {
@@ -60,6 +60,6 @@ var transforms = [
 test('singleline transforms', function (t) {
   t.plan(transforms.length)
   transforms.forEach(function (obj) {
-    t.equal(fmt(obj.str), obj.expect, obj.msg)
+    t.equal(fmt(obj.str).substring(15), obj.expect, obj.msg)
   })
 })


### PR DESCRIPTION
This commit fixes the tests and adds support for setting the indent when used via API or detecting indent when used on the command line. The default remains 4 when the indentation cannot be determined.

cc: @raynos @lxe 
