### PR TITLE
Fix commondir error so package can be used

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.js]
+indent_style = space
+indent_size = 2

--- a/bin.js
+++ b/bin.js
@@ -73,16 +73,25 @@ function getFiles (done) {
   }
 }
 
+function getRoot(files) {
+  if (files[0] && files[0].name === 'stdin') {
+      return process.cwd();
+  }
+  var fileNames = files.map(function getName(file) {
+      return file.name;
+  });
+  return commondir('./', fileNames);
+}
+
 getFiles(function (err, files) {
   if (err) return error(err)
-  var root = (files[0] && files[0].name === 'stdin') ?
-    process.cwd() : commondir(files)
+  var root = getRoot(files);
   editorConfigGetIndent(root, function (err, indent) {
-    if (err) return error(err)
-    files.forEach(function (file) {
-      file.data = fmt.transform(file.data, indent)
-      processFile(file)
-    })
+      if (err) return error(err)
+      files.forEach(function (file) {
+          file.data = fmt.transform(file.data, indent)
+          processFile(file)
+      })
   })
 })
 


### PR DESCRIPTION
@malandrew 

Running current code results in an error:

```
willy@localhost:~/Projects/troy/standard-format (master)$ node bin.js bin.js 

/home/willy/Projects/troy/standard-format/node_modules/commondir/index.js:25
    }, files[0].split(/\/+|\\+/));
                ^
TypeError: Object #<Object> has no method 'split'
    at module.exports (/home/willy/Projects/troy/standard-format/node_modules/commondir/index.js:25:17)
    at /home/willy/Projects/troy/standard-format/bin.js:79:21
    at getFiles (/home/willy/Projects/troy/standard-format/bin.js:70:12)
    at Object.<anonymous> (/home/willy/Projects/troy/standard-format/bin.js:76:1)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
```

This fixes the error and allows formatting again.
